### PR TITLE
Add ga4 (fixes #11537)

### DIFF
--- a/mozilla-custom.php
+++ b/mozilla-custom.php
@@ -4,7 +4,7 @@ Plugin Name: Mozilla Custom Plugins
 Plugin URI: https://blog.mozilla.org
 Description: Does custom things that we need
 Version: .4
-Author: Jeremiah Orem, Craig Cook
+Author: Jeremiah Orem, Craig Cook, Maureen Holland
 */
 
     // Our plugin

--- a/mozilla-custom.php
+++ b/mozilla-custom.php
@@ -3,7 +3,7 @@
 Plugin Name: Mozilla Custom Plugins
 Plugin URI: https://blog.mozilla.org
 Description: Does custom things that we need
-Version: .3
+Version: .4
 Author: Jeremiah Orem, Craig Cook
 */
 

--- a/mozilla-custom/ga-snippet.js
+++ b/mozilla-custom/ga-snippet.js
@@ -69,5 +69,22 @@ Mozilla.dntEnabled = function(dnt, ua) {
         ga('create', 'UA-36116321-4', 'auto');
         ga('set', 'dimension1', blogName);
         ga('send', 'pageview');
+
+        // Activate new GA4 measurement ID through gtag script
+        var measurementId = 'G-X4N05QV93S';
+
+        (function(doc, tag, url) {
+            var newScript = doc.createElement(tag);
+            newScript.async = 1;
+            newScript.src = url;
+            existingScript = doc.getElementsByTagName(tag)[0]
+            existingScript.parentNode.insertBefore(newScript, existingScript)
+        })(document, 'script', 'https://www.googletagmanager.com/gtag/js?id=' + measurementId)
+
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', measurementId);
     }
 })();

--- a/mozilla-custom/ga-snippet.js
+++ b/mozilla-custom/ga-snippet.js
@@ -77,7 +77,7 @@ Mozilla.dntEnabled = function(dnt, ua) {
             var newScript = doc.createElement(tag);
             newScript.async = 1;
             newScript.src = url;
-            existingScript = doc.getElementsByTagName(tag)[0]
+            var existingScript = doc.getElementsByTagName(tag)[0]
             existingScript.parentNode.insertBefore(newScript, existingScript)
         })(document, 'script', 'https://www.googletagmanager.com/gtag/js?id=' + measurementId)
 


### PR DESCRIPTION
Issue: https://github.com/mozilla/bedrock/issues/11537

We need a gtag script to start sending data to a GA4 property ([analytics.js is not able to connect with GA4](https://support.google.com/analytics/answer/11091026#analytics-js-dual-tagging&zippy=%2Cin-this-article))

This addition continues to respect user's DNT preference and conditionally creates gtag script to connect with new GA4 property's measurement ID. The analytics.js script is unchanged to preserve Universal Analytics data for now. This analytics.js script will be removed eventually as Universal Analytics will stop processing new hits July 1 2023. But we want to run them simultaneously for a while.

🚧 WIP, untested